### PR TITLE
Various minor adjustments

### DIFF
--- a/memory/types.lua
+++ b/memory/types.lua
@@ -77,13 +77,14 @@ local linkshell_color = struct({
 })
 
 local model = struct({
-    head                    = {0x0, uint16},
-    body                    = {0x2, uint16},
-    hands                   = {0x4, uint16},
-    legs                    = {0x6, uint16},
-    feet                    = {0x8, uint16},
-    main                    = {0xA, uint16},
-    ranged                  = {0xC, uint16},
+    head_model_id           = {0x0, uint16},
+    body_model_id           = {0x2, uint16},
+    hands_model_id          = {0x4, uint16},
+    legs_model_id           = {0x6, uint16},
+    feet_model_id           = {0x8, uint16},
+    main_model_id           = {0xA, uint16},
+    sub_model_id            = {0xC, uint16},
+    range_model_id          = {0xE, uint16},
 })
 
 local display = struct({
@@ -118,8 +119,8 @@ local entity = struct({
     owner                   = {0x0E8, entity_id},
     hp_percent              = {0x0EC, percent},
     target_type             = {0x0EE, uint8}, -- 0 = PC, 1 = NPC, 2 = NPC with fixed model (including various types of books), 3 = Doors and similar objects
-    race                    = {0x0EF, uint16},
-    face                    = {0x0FC, uint16},
+    race_id                 = {0x0EF, uint16},
+    face_model_id           = {0x0FC, uint16},
     model                   = {0x0FE, model},
     freeze                  = {0x11C, bool},
     flags                   = {0x120, uint32[0x06]},

--- a/player_service/player_service.lua
+++ b/player_service/player_service.lua
@@ -44,16 +44,16 @@ packets.incoming:register_init({
         if p.update_model then
             local model = data.model
             local m = p.model
-            model.face = m.face
-            model.race = m.race
-            model.head = m.head
-            model.body = m.body
-            model.hands = m.hands
-            model.legs = m.legs
-            model.feet = m.feet
-            model.main = m.main
-            model.sub = m.sub
-            model.range = m.range
+            data.race_id = m.race_id
+            model.face_id = m.face_model_id
+            model.head_id = m.head_model_id
+            model.body_id = m.body_model_id
+            model.hands_id = m.hands_model_id
+            model.legs_id = m.legs_model_id
+            model.feet_id = m.feet_model_id
+            model.main_id = m.main_model_id
+            model.sub_id = m.sub_model_id
+            model.range_id = m.range_model_id
         end
     end,
 
@@ -71,10 +71,9 @@ packets.incoming:register_init({
 
     [{0x01B}] = function(p)
         local data = player.data
+        data.race_id = p.race_id
         data.main_job_id = p.main_job_id
-        data.main_job_level = p.main_job_level
         data.sub_job_id = p.sub_job_id
-        data.sub_job_level = p.sub_job_level
         data.hp_max = p.hp_max
         data.mp_max = p.mp_max
         for i = 0, 0x17 do


### PR DESCRIPTION
* Make the model struct homogenous across memory and packets.
* Append _id suffixes to some variables (see discord)
* Address a few of the #BYRTH# messages.
* Fix the 0x1B packet.