### PR TITLE
Fix target.select function

### DIFF
--- a/target/manifest.xml
+++ b/target/manifest.xml
@@ -1,6 +1,6 @@
 <package>
   <name>target</name>
-  <version>1.2.0.0</version>
+  <version>1.2.1.0</version>
   <type>library</type>
   <dependencies>
     <dependency>entities</dependency>

--- a/target/target.lua
+++ b/target/target.lua
@@ -91,7 +91,7 @@ if package then
             local temp = counter
             counter = tobit(counter + 1)
             table.insert(pending, {counter = temp, callback = callback})
-            command.input('/:aim \u{FFFD}select_sub_target\u{FFFD} "' .. package .. '" ' .. temp .. ' ' .. target)
+            command.input('/:aim \u{FFFD}select_sub_target\u{FFFD} "' .. package .. '" ' .. temp .. ' <' .. target .. '>')
         end
 
         key_fns.select = function() return select end


### PR DESCRIPTION
Forgot to add `<` and `>` to the command string after removing them from the argument.