### PR TITLE
Pack: fix bug in an assert

### DIFF
--- a/pack/manifest.xml
+++ b/pack/manifest.xml
@@ -1,5 +1,5 @@
 <package>
   <name>pack</name>
-  <version>1.0.0.1</version>
+  <version>1.0.0.2</version>
   <type>library</type>
 </package>

--- a/pack/pack.lua
+++ b/pack/pack.lua
@@ -71,10 +71,10 @@ string.pack = function(format, ...)
 
         while count > 0 do
             index = index + 1
-            assert(index <= args, 'Bad argument #' .. tostring(index) .. ' to \'pack\' (' .. info.type .. ' expected, got no value)')
+            assert(index <= args, 'Bad argument #' .. tostring(index + 1) .. ' to \'pack\' (' .. info.type .. ' expected, got no value)')
 
             local value = select(index, ...)
-            assert(type(value) == info.type, 'Bad argument #' .. tostring(index) .. ' to \'pack\' (' .. info.type .. ' expected, got ' .. type(value) .. ')')
+            assert(type(value) == info.type, 'Bad argument #' .. tostring(index + 1) .. ' to \'pack\' (' .. info.type .. ' expected, got ' .. type(value) .. ')')
 
             if offset >= 8 then
                 res[#res + 1], offset, current = convert_number(current, offset, 7)

--- a/pack/pack.lua
+++ b/pack/pack.lua
@@ -114,7 +114,7 @@ string.pack = function(format, ...)
         end
     end
 
-    assert(index >= args, 'Bad argument #' .. tostring(index + 2) .. ' to \'pack\' (no value expected, got ' .. type(select(index + 2, ...)) .. ')')
+    assert(index >= args, 'Bad argument #' .. tostring(index + 2) .. ' to \'pack\' (no value expected, got ' .. type(select(index + 1, ...) or nil) .. ')')
 
     if offset > 0 then
         res[#res + 1] = convert_number(current, offset, 0)


### PR DESCRIPTION
change select to read the next argument instead of 2 ahead
provide a fallback value when select returns nothing