### PR TITLE
Added option_index for outgoing[0x05C] packet.

### DIFF
--- a/packet_service/manifest.xml
+++ b/packet_service/manifest.xml
@@ -1,6 +1,6 @@
 <package>
   <name>packet_service</name>
-  <version>3.1.6.0</version>
+  <version>3.1.7.0</version>
   <type>service</type>
   <dependencies>
     <dependency>file</dependency>

--- a/packet_service/types.lua
+++ b/packet_service/types.lua
@@ -2869,7 +2869,7 @@ types.outgoing[0x05C] = struct({
     z                   = {0x04, float},
     y                   = {0x08, float},
     target_id           = {0x0C, entity},
-    -- 0x10~0x13: 01 00 00 00 observed
+    option_index        = {0x10, uint32},
     zone_id             = {0x14, zone},
     menu_id             = {0x16, uint16},
     target_index        = {0x18, entity_index},


### PR DESCRIPTION
This is required for superwarp's same-zone warp requests to work.