### PR TITLE
Fix scanner module name in require call

### DIFF
--- a/addons/ime/ime.lua
+++ b/addons/ime/ime.lua
@@ -1,4 +1,4 @@
-local scanner = require('scanner')
+local scanner = require('core.scanner')
 local ffi = require('ffi')
 
 local language_check

--- a/addons/ime/manifest.xml
+++ b/addons/ime/manifest.xml
@@ -1,5 +1,5 @@
 <package>
   <name>ime</name>
-  <version>1.0.0.2</version>
+  <version>1.0.0.3</version>
   <type>addon</type>
 </package>


### PR DESCRIPTION
The built in `scanner` module was renamed to `core.scanner`.