### PR TITLE
Addon:burdometer layout style and transparency tweak

### DIFF
--- a/addons/burdometer/burdometer.lua
+++ b/addons/burdometer/burdometer.lua
@@ -25,7 +25,7 @@ local burden_window = {
         y = options.ui.y,
         width = 118,
         height = 144,
-        color = options.window_style == 'chromeless' and ui.color.rgb(0,0,0,40) or nil,
+        color = options.window_style == 'chromeless' and ui.color.transparent or nil,
         resizable = false,
         moveable = true,
     }
@@ -43,11 +43,11 @@ local function set_window_style(style)
     options.window_style = style
 
     burden_window.state.style = style
-    burden_window.state.color = options.window_style == 'chromeless' and ui.color.rgb(0,0,0,40) or nil
+    burden_window.state.color = options.window_style == 'chromeless' and ui.color.transparent or nil
 
     settings.save()
 end
-cmd:register('style', set_window_style, '<window_style:one_of(chromeless,normal)>')
+cmd:register('style', set_window_style, '<window_style:one_of(chromeless,normal,layout)>')
 
 
 local function draw_burden(element, value, y)

--- a/addons/burdometer/burdometer.lua
+++ b/addons/burdometer/burdometer.lua
@@ -101,6 +101,9 @@ ui.display(function()
             height = height + 18
         end
     end
+    if burden_window.state.style == 'layout' then
+        height = 144
+    end
     burden_window.state.height = height
 
     burden_window.state, burden_window.closed = ui.window('burden_window', burden_window.state, function()

--- a/addons/burdometer/manifest.xml
+++ b/addons/burdometer/manifest.xml
@@ -1,6 +1,6 @@
 <package>
   <name>burdometer</name>
-  <version>0.9.0.2</version>
+  <version>0.9.1.0</version>
   <type>addon</type>
   <dependencies>
     <dependency>set</dependency>


### PR DESCRIPTION
Two small changes:
* Make chromeless window style fully transparent instead of almost so
* Add layout as a style option for more intuitive repositioning
  * Window height is maxed while in layout style for better visualization of positioning