### PR TITLE
add a check for if the player is on PUP

### DIFF
--- a/addons/burdometer/burden.lua
+++ b/addons/burdometer/burden.lua
@@ -1,8 +1,9 @@
 local os = require("os")
-local set = require("set")
-local player = require("player")
-local packet = require("packet")
+
 local equipment = require("equipment")
+local packet = require("packet")
+local player = require("player")
+local set = require("set")
 local status_effects = require("status_effects")
 
 local o = {

--- a/addons/burdometer/burden.lua
+++ b/addons/burdometer/burden.lua
@@ -1,10 +1,10 @@
-local os = require("os")
+local os = require('os')
 
-local equipment = require("equipment")
-local packet = require("packet")
-local player = require("player")
-local set = require("set")
-local status_effects = require("status_effects")
+local equipment = require('equipment')
+local packet = require('packet')
+local player = require('player')
+local set = require('set')
+local status_effects = require('status_effects')
 
 local o = {
     fire = 0,
@@ -75,18 +75,18 @@ local thresholdModifiers =
 burden.threshold = 30
 
 local pet_actions = {
-    [136] = "activate",
-    [139] = "deactivate",
-    [141] = "fire",
-    [142] = "ice",
-    [143] = "wind",
-    [144] = "earth",
-    [145] = "thunder",
-    [146] = "water",
-    [147] = "light",
-    [148] = "dark",
-    [309] = "cooldown",
-    [310] = "deus_ex_automata",
+    [136] = 'activate',
+    [139] = 'deactivate',
+    [141] = 'fire',
+    [142] = 'ice',
+    [143] = 'wind',
+    [144] = 'earth',
+    [145] = 'thunder',
+    [146] = 'water',
+    [147] = 'light',
+    [148] = 'dark',
+    [309] = 'cooldown',
+    [310] = 'deus_ex_automata',
 }
 
 local maneuvers = set(
@@ -143,14 +143,14 @@ function updaters.maneuver(self, type)
     end
 end
 
-function updaters.ice(self) updaters.maneuver(self, "ice") end
-function updaters.fire(self) updaters.maneuver(self, "fire") end
-function updaters.wind(self) updaters.maneuver(self, "wind") end
-function updaters.dark(self) updaters.maneuver(self, "dark") end
-function updaters.earth(self) updaters.maneuver(self, "earth") end
-function updaters.water(self) updaters.maneuver(self, "water") end
-function updaters.light(self) updaters.maneuver(self, "light") end
-function updaters.thunder(self) updaters.maneuver(self, "thunder") end
+function updaters.ice(self) updaters.maneuver(self, 'ice') end
+function updaters.fire(self) updaters.maneuver(self, 'fire') end
+function updaters.wind(self) updaters.maneuver(self, 'wind') end
+function updaters.dark(self) updaters.maneuver(self, 'dark') end
+function updaters.earth(self) updaters.maneuver(self, 'earth') end
+function updaters.water(self) updaters.maneuver(self, 'water') end
+function updaters.light(self) updaters.maneuver(self, 'light') end
+function updaters.thunder(self) updaters.maneuver(self, 'thunder') end
 
 burden.decay_rate = 1
 function burden.decay()

--- a/addons/burdometer/burdometer.lua
+++ b/addons/burdometer/burdometer.lua
@@ -109,7 +109,7 @@ local ele_order = {
 }
 
 ui.display(function()
-    if not (player.main_job_id == 0x12 or player.sub_job_id == 0x12) then
+    if not (player.main_job_id == 0x12 or player.sub_job_id == 0x12 or burden_window.state.style == 'layout') then
         return
     end
     local height = 0

--- a/addons/burdometer/burdometer.lua
+++ b/addons/burdometer/burdometer.lua
@@ -1,11 +1,13 @@
-local burden = require('burden')
 local string = require('string')
-local settings = require('settings')
 
 local ui = require('core.ui')
 local command = require('core.command')
 local windower = require('core.windower')
 
+local player = require('player')
+local settings = require('settings')
+
+local burden = require('burden')
 
 local defaults = {
     ui = {
@@ -107,6 +109,9 @@ local ele_order = {
 }
 
 ui.display(function()
+    if not (player.main_job_id == 0x12 or player.sub_job_id == 0x12) then
+        return
+    end
     local height = 0
     for _, v in pairs(burden) do
         if v ~= 0 then

--- a/addons/burdometer/manifest.xml
+++ b/addons/burdometer/manifest.xml
@@ -1,13 +1,13 @@
 <package>
   <name>burdometer</name>
-  <version>0.9.1.1</version>
+  <version>0.9.1.2</version>
   <type>addon</type>
   <dependencies>
-    <dependency>set</dependency>
-    <dependency>player</dependency>
-    <dependency>packet</dependency>
-    <dependency>settings</dependency>
     <dependency>equipment</dependency>
+    <dependency>packet</dependency>
+    <dependency>player</dependency>
+    <dependency>set</dependency>
+    <dependency>settings</dependency>
     <dependency>status_effects</dependency>
   </dependencies>
 </package>


### PR DESCRIPTION
This prevents the window from showing up intermittently while on other jobs, such after zoning. Also hides it when not logged in since jobs are set to 0.

This could be changed to check for an active automaton once the pet library is available.